### PR TITLE
Fixed double-quote issue with tripUUIDs for motion files

### DIFF
--- a/android/Bumpy/app/src/main/java/com/cycling_advocacy/bumpy/net/DataSender.java
+++ b/android/Bumpy/app/src/main/java/com/cycling_advocacy/bumpy/net/DataSender.java
@@ -112,8 +112,10 @@ public class DataSender {
         RequestBody motionDataFileRB = RequestBody.create(MediaType.parse("text/csv"), motionDataFile);
         MultipartBody.Part motionDataFilePart = MultipartBody.Part.createFormData("file", motionDataFile.getName(), motionDataFileRB);
 
+        RequestBody plainTripUUID = RequestBody.create(MediaType.parse("text/plain"), trip.getTripUUID());
+
         BumpyService bumpyService = BumpyServiceBuilder.createService(BumpyService.class);
-        bumpyService.uploadMotionData(trip.getTripUUID(), motionDataFilePart)
+        bumpyService.uploadMotionData(plainTripUUID, motionDataFilePart)
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(new SingleObserver<Response<ApiResponse>>() {

--- a/android/Bumpy/app/src/main/java/com/cycling_advocacy/bumpy/net/service/BumpyService.java
+++ b/android/Bumpy/app/src/main/java/com/cycling_advocacy/bumpy/net/service/BumpyService.java
@@ -9,6 +9,7 @@ import java.util.List;
 
 import io.reactivex.Single;
 import okhttp3.MultipartBody;
+import okhttp3.RequestBody;
 import retrofit2.Response;
 import retrofit2.http.Body;
 import retrofit2.http.DELETE;
@@ -25,7 +26,7 @@ public interface BumpyService {
 
     @Multipart
     @POST("trip/uploadMotionFile")
-    Single<Response<ApiResponse>> uploadMotionData(@Part("tripUUID") String tripUUID, @Part MultipartBody.Part file);
+    Single<Response<ApiResponse>> uploadMotionData(@Part("tripUUID") RequestBody tripUUID, @Part MultipartBody.Part file);
 
     @GET("trip/getTripsByDeviceUUID")
     Single<Response<List<PastTripGeneralResponse>>> getTripsByDeviceUUID(@Query("deviceUUID") String deviceUUID);


### PR DESCRIPTION
Implementation fixes the double-quotes issue of tripUUID when sending motion.csv file from Android.